### PR TITLE
Add minimal C++ photo editor prototype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10)
+project(VisualCodePhotoEditor)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(OpenCV REQUIRED)
+
+add_executable(photo_editor
+    src/main.cpp
+    src/Catalog.cpp
+    src/ImageProcessor.cpp
+)
+
+target_include_directories(photo_editor PRIVATE ${OpenCV_INCLUDE_DIRS})
+target_link_libraries(photo_editor PRIVATE ${OpenCV_LIBS})

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# VisualCode
+# VisualCode Photo Editor Prototype
+
+This repository contains a minimal C++ photo editing prototype intended for use with Visual Studio Code. It demonstrates a basic catalog loader and simple brightness/contrast adjustments using OpenCV. The project is **not** a full replacement for professional tools like Photoshop or Lightroom, but it can serve as a foundation for further development.
+
+## Features
+
+- Scan a folder for common image files (`jpg`, `png`, `dng`, `tiff`, `bmp`).
+- Apply basic brightness and contrast adjustments.
+- Save processed images to the working directory.
+
+Several advanced features requested (AI metadata insertion, generative AI, professional denoise, social media integration, etc.) are not implemented here. Stubs and TODO comments are provided where such functionality could be added.
+
+## Building
+
+This project uses CMake and requires OpenCV to be installed.
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+Run the executable by passing a path to a folder of images:
+
+```bash
+./photo_editor ../path/to/catalog
+```
+
+## Future Work
+
+- Implement mask adjustments and advanced AI tools.
+- Add preset management and style libraries.
+- Integrate with external editors and social media APIs.
+

--- a/src/Catalog.cpp
+++ b/src/Catalog.cpp
@@ -1,0 +1,22 @@
+#include "Catalog.h"
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+Catalog::Catalog(const std::string &path) : path_(path) {}
+
+bool Catalog::scan() {
+    images_.clear();
+    try {
+        for (const auto &entry : fs::directory_iterator(path_)) {
+            if (!entry.is_regular_file()) continue;
+            auto ext = entry.path().extension().string();
+            if (ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".dng" || ext == ".tiff" || ext == ".bmp") {
+                images_.push_back(entry.path().string());
+            }
+        }
+    } catch (const std::exception &e) {
+        return false;
+    }
+    return true;
+}

--- a/src/Catalog.h
+++ b/src/Catalog.h
@@ -1,0 +1,21 @@
+#ifndef CATALOG_H
+#define CATALOG_H
+
+#include <string>
+#include <vector>
+
+class Catalog {
+public:
+    explicit Catalog(const std::string &path);
+
+    // load image file paths
+    bool scan();
+
+    const std::vector<std::string> &images() const { return images_; }
+
+private:
+    std::string path_;
+    std::vector<std::string> images_;
+};
+
+#endif // CATALOG_H

--- a/src/ImageProcessor.cpp
+++ b/src/ImageProcessor.cpp
@@ -1,0 +1,25 @@
+#include "ImageProcessor.h"
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+
+ImageProcessor::ImageProcessor() {}
+
+bool ImageProcessor::load(const std::string &path) {
+    img_ = cv::imread(path, cv::IMREAD_UNCHANGED);
+    return !img_.empty();
+}
+
+bool ImageProcessor::save(const std::string &path) {
+    if (img_.empty()) return false;
+    return cv::imwrite(path, img_);
+}
+
+void ImageProcessor::adjustBrightness(int value) {
+    if (img_.empty()) return;
+    img_.convertTo(img_, -1, 1, value);
+}
+
+void ImageProcessor::adjustContrast(double alpha) {
+    if (img_.empty()) return;
+    img_.convertTo(img_, -1, alpha, 0);
+}

--- a/src/ImageProcessor.h
+++ b/src/ImageProcessor.h
@@ -1,0 +1,31 @@
+#ifndef IMAGEPROCESSOR_H
+#define IMAGEPROCESSOR_H
+
+#include <string>
+#include <opencv2/opencv.hpp>
+
+class ImageProcessor {
+public:
+    ImageProcessor();
+
+    // load image from file
+    bool load(const std::string &path);
+
+    // save image to file
+    bool save(const std::string &path);
+
+    // adjust brightness [-100,100]
+    void adjustBrightness(int value);
+
+    // adjust contrast [0.0, 3.0]
+    void adjustContrast(double alpha);
+
+    // TODO: implement more advanced features (masks, AI, etc.)
+
+    const cv::Mat &image() const { return img_; }
+
+private:
+    cv::Mat img_;
+};
+
+#endif // IMAGEPROCESSOR_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,39 @@
+#include "Catalog.h"
+#include "ImageProcessor.h"
+#include <iostream>
+#include <filesystem>
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <catalog_path>" << std::endl;
+        return 1;
+    }
+
+    Catalog catalog(argv[1]);
+    if (!catalog.scan()) {
+        std::cerr << "Failed to scan catalog" << std::endl;
+        return 1;
+    }
+
+    std::cout << "Loaded " << catalog.images().size() << " images." << std::endl;
+
+    // simple loop through images
+    for (const auto &path : catalog.images()) {
+        ImageProcessor proc;
+        if (!proc.load(path)) {
+            std::cerr << "Failed to load " << path << std::endl;
+            continue;
+        }
+        // placeholder: automatic AI analysis would go here
+        proc.adjustBrightness(10); // example operation
+        proc.adjustContrast(1.2);  // example operation
+
+        // save to output folder
+        std::string output = "processed_" + std::string(std::filesystem::path(path).filename());
+        proc.save(output);
+        std::cout << "Processed " << path << " -> " << output << std::endl;
+    }
+
+    std::cout << "Processing complete." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- initialize CMake-based project with OpenCV dependency
- implement basic Catalog and ImageProcessor classes
- add a simple `main.cpp` that processes images in a folder
- document the build and usage steps

## Testing
- `cmake ..`
- `make`
- `./photo_editor nonexistent_path` *(fails to scan catalog)*

------
https://chatgpt.com/codex/tasks/task_e_68599aa17b148327857772648ec6dec5