### PR TITLE
Add release step to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,3 +16,9 @@ jobs:
         run: cmake -B build -S .
       - name: Build
         run: cmake --build build
+      - name: Release
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.sha }}
+          name: Release ${{ github.sha }}


### PR DESCRIPTION
## Summary
- publish releases on pushes to `main` via softprops/action-gh-release

## Testing
- `bash -lc 'git status --short'`

------
https://chatgpt.com/codex/tasks/task_e_6859abf1ddb083278146901958f07e66