### PR TITLE
Add AI metadata insertion feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ project(VisualCodePhotoEditor)
 set(CMAKE_CXX_STANDARD 17)
 
 find_package(OpenCV REQUIRED)
+find_package(PkgConfig)
+if(PkgConfig_FOUND)
+    pkg_check_modules(EXIV2 REQUIRED exiv2)
+endif()
 
 add_executable(photo_editor
     src/main.cpp
@@ -11,5 +15,5 @@ add_executable(photo_editor
     src/ImageProcessor.cpp
 )
 
-target_include_directories(photo_editor PRIVATE ${OpenCV_INCLUDE_DIRS})
-target_link_libraries(photo_editor PRIVATE ${OpenCV_LIBS})
+target_include_directories(photo_editor PRIVATE ${OpenCV_INCLUDE_DIRS} ${EXIV2_INCLUDE_DIRS})
+target_link_libraries(photo_editor PRIVATE ${OpenCV_LIBS} ${EXIV2_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ This repository contains a minimal C++ photo editing prototype intended for use 
 - Scan a folder for common image files (`jpg`, `png`, `dng`, `tiff`, `bmp`).
 - Apply basic brightness and contrast adjustments.
 - Save processed images to the working directory.
+- Insert simple AI metadata into processed images.
 
-Several advanced features requested (AI metadata insertion, generative AI, professional denoise, social media integration, etc.) are not implemented here. Stubs and TODO comments are provided where such functionality could be added.
+Several advanced features requested (generative AI, professional denoise, social media integration, etc.) are not implemented here. Stubs and TODO comments are provided where such functionality could be added.
 
 ## Building
 
-This project uses CMake and requires OpenCV to be installed.
+This project uses CMake and requires OpenCV and Exiv2 to be installed.
 
 ```bash
 mkdir build

--- a/src/ImageProcessor.cpp
+++ b/src/ImageProcessor.cpp
@@ -1,11 +1,17 @@
 #include "ImageProcessor.h"
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc.hpp>
+#include <exiv2/exiv2.hpp>
 
 ImageProcessor::ImageProcessor() {}
 
 bool ImageProcessor::load(const std::string &path) {
     img_ = cv::imread(path, cv::IMREAD_UNCHANGED);
+    if (!img_.empty()) {
+        loaded_path_ = path;
+    } else {
+        loaded_path_.clear();
+    }
     return !img_.empty();
 }
 
@@ -22,4 +28,19 @@ void ImageProcessor::adjustBrightness(int value) {
 void ImageProcessor::adjustContrast(double alpha) {
     if (img_.empty()) return;
     img_.convertTo(img_, -1, alpha, 0);
+}
+
+bool ImageProcessor::insertMetadata(const std::string &key, const std::string &value) {
+    if (loaded_path_.empty()) return false;
+    try {
+        auto image = Exiv2::ImageFactory::open(loaded_path_);
+        image->readMetadata();
+        Exiv2::ExifData &exifData = image->exifData();
+        exifData[key] = value;
+        image->setExifData(exifData);
+        image->writeMetadata();
+        return true;
+    } catch (const Exiv2::Error &e) {
+        return false;
+    }
 }

--- a/src/ImageProcessor.h
+++ b/src/ImageProcessor.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <opencv2/opencv.hpp>
+#include <exiv2/exiv2.hpp>
 
 class ImageProcessor {
 public:
@@ -20,12 +21,16 @@ public:
     // adjust contrast [0.0, 3.0]
     void adjustContrast(double alpha);
 
+    // insert custom metadata into the loaded image
+    bool insertMetadata(const std::string &key, const std::string &value);
+
     // TODO: implement more advanced features (masks, AI, etc.)
 
     const cv::Mat &image() const { return img_; }
 
 private:
     cv::Mat img_;
+    std::string loaded_path_;
 };
 
 #endif // IMAGEPROCESSOR_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,9 @@ int main(int argc, char **argv) {
         proc.adjustBrightness(10); // example operation
         proc.adjustContrast(1.2);  // example operation
 
+        // insert simple AI metadata
+        proc.insertMetadata("Exif.Image.Software", "VisualCode AI v1");
+
         // save to output folder
         std::string output =
             "processed_" + std::string(std::filesystem::path(path).filename());


### PR DESCRIPTION
## Summary
- store loaded image path and use Exiv2 to write metadata
- expose `insertMetadata` in `ImageProcessor`
- call metadata insertion from the main program
- depend on Exiv2 through pkg-config
- document the new feature in README

## Testing
- `cmake .. && cmake --build .`
- `./photo_editor . 2>&1 | head`

------
https://chatgpt.com/codex/tasks/task_e_6859b4bbd69c8327a7fd34a658ab4110