### PR TITLE
Update vcpkg install method

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install vcpkg
-        run: choco install vcpkg -y
+        run: |
+          git clone https://github.com/microsoft/vcpkg C:\vcpkg
+          C:\vcpkg\bootstrap-vcpkg.bat
+          "VCPKG_INSTALLATION_ROOT=C:\vcpkg" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Install dependencies
         run: |
-          $env:VCPKG_INSTALLATION_ROOT = "C:\\ProgramData\\chocolatey\\lib\\vcpkg\\tools\\vcpkg"
           $env:VCPKG_DEFAULT_TRIPLET = "x64-windows"
-          vcpkg install exiv2 opencv
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install exiv2 opencv
       - name: Configure
         run: cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake
       - name: Build


### PR DESCRIPTION
## Summary
- clone vcpkg from GitHub in Windows workflow
- bootstrap vcpkg and set `VCPKG_INSTALLATION_ROOT`
- install exiv2 and opencv using the cloned vcpkg

## Testing
- `cmake --version`

------
https://chatgpt.com/codex/tasks/task_e_6859bef66e7083278d09c07da76d7dd4