### PR TITLE
Fix path to string conversion for MSVC

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
 
         // save to output folder
         std::string output =
-            "processed_" + std::string(std::filesystem::path(path).filename());
+            "processed_" + std::filesystem::path(path).filename().string();
         proc.save(output);
         std::cout << "Processed " << path << " -> " << output << std::endl;
     }


### PR DESCRIPTION
## Summary
- fix MSVC build error by calling `std::filesystem::path::filename().string()`

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by `OpenCV`)*

------
https://chatgpt.com/codex/tasks/task_e_6859d4b5cf108327820d3e2598a89d76