### PR TITLE
Add .exe artifact to release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,13 @@ jobs:
         run: cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_INSTALLATION_ROOT }}\scripts\buildsystems\vcpkg.cmake
       - name: Build
         run: cmake --build build --config Release
+      - name: Package executable
+        run: |
+          mkdir artifacts
+          cp build/Release/photo_editor.exe artifacts/photo_editor.exe
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ github.sha }}
           name: Windows Release v${{ github.sha }}
+          files: artifacts/photo_editor.exe

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ OpenCV, runs CMake configuration, and builds the executable to verify that
 the code compiles successfully. You can find the configuration in
 `.github/workflows/build.yml`.
 
+On Windows, the workflow also packages a build artifact named
+`photo_editor.exe` and attaches it to a GitHub release so you can download
+and run the editor without building it yourself.
+
 ## Future Work
 
 - Implement mask adjustments and advanced AI tools.


### PR DESCRIPTION
## Summary
- package the Windows build as `photo_editor.exe` in the release workflow
- document the Windows release artifact in the README

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "OpenCV" with any of the following names: OpenCVConfig.cmake opencv-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68629321ebbc83278aebcb1a6d9fad51